### PR TITLE
Convert GitHub markdown to JIRA before submitting

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -78,6 +78,21 @@ runs:
       run: |
         set -eux
 
+        # Convert markdown to JIRA using mistletoe package which is available starting with impish.
+        # Since GH runners only have LTS versions it's safe to only check for focal which doesn't have the package.
+        if [ $(lsb_release -c -s) == "focal" ]; then
+          echo "Converting Markdown to JIRA is only possible starting with Ubuntu 22.04 (jammy). Pushing verbatim content to JIRA..."
+        else
+          TMPDIR=$(mktemp -d)
+          trap 'rm -rf -- "$TMPDIR"' EXIT
+
+          sudo apt install -y python3-mistletoe
+          echo ${body} > $TMPDIR/body.md
+          echo ${comment} > $TMPDIR/comment.md
+          body=$(PYTHONPATH=/usr/share/doc/python3-mistletoe mistletoe -r examples.jira_renderer.JIRARenderer $TMPDIR/body.md)
+          comment=$(PYTHONPATH=/usr/share/doc/python3-mistletoe mistletoe -r examples.jira_renderer.JIRARenderer $TMPDIR/comment.md)
+        fi
+
         description="${body}
 
         Opened by ${author}."


### PR DESCRIPTION
I found a package that can convert Markdown to JIRA, unfortunately it's only available starting with impish (21.10) so the first LTS that has it is jammy (22.04) which [is not yet the default](https://github.com/actions/virtual-environments#available-environments) `ubuntu-latest` for GitHub runners.

However in this case I think we can make an exception in our consumer repo(s) to run on `ubuntu-22.04` instead of `ubuntu-latest`.

I tested this in a local repo and confirmed it works by checking the output for both `ubuntu-22.04` and `ubuntu-latest` (focal).