### PR TITLE
Fix labels with spaces

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -20,6 +20,9 @@ runs:
     #  run: echo '${{ toJSON(github) }}'
     #  shell: bash
     - name: restrict action to labelled issues and issue comments
+      env:
+        label: ${{ github.event.label.name }}
+        jiraLabel: ${{ inputs.label }}
       run: |
         set -eux
 
@@ -46,7 +49,7 @@ runs:
         ## check if one label of labels is our jira label
         toconsider=${{ contains(github.event.issue.labels.*.name, inputs.label) }}
         ## second chance, this has just been unlabeled and needs to be deleted on Jira
-        if [ "${{ github.event.action }}" == "unlabeled" ] && [ "${{ github.event.label.name }}" == "${{ inputs.label }}" ]; then
+        if [ "${{ github.event.action }}" == "unlabeled" ] && [ "$label" == "$jiraLabel" ]; then
           toconsider=true
         fi
         if [ "${toconsider}" == false ]; then
@@ -55,7 +58,7 @@ runs:
         fi
 
         # And finally, for the "labeled" event, we are only interested if the new added label is our desired one.
-        if [ "${{ github.event.action }}" == "labeled" ] && [ "${{ github.event.label.name }}" != "${{ inputs.label }}" ]; then
+        if [ "${{ github.event.action }}" == "labeled" ] && [ "$label" != "$jiraLabel" ]; then
           echo "Not interested in this action, skipping"
           exit 0
         fi


### PR DESCRIPTION
fixes #17 

Previously labels with spaces would cause the action to create or delete Jira tasks when it shouldn't. By quoting the label this is fixed. Also this fix uses environment variables to account for labels such as `lab"el` and `label\`